### PR TITLE
Update SwiftClipper to use Doubles and fix some issues

### DIFF
--- a/Sources/SwiftClipper/ClipperBase.swift
+++ b/Sources/SwiftClipper/ClipperBase.swift
@@ -26,19 +26,19 @@ public class ClipperBase {
     }
 
     class LocalMinima {
-        var y: CGFloat = 0
+        var y: Double = 0
         var leftBound: TEdge!
         var rightBound: TEdge!
         var next: LocalMinima!
     }
 
     class Scanbeam {
-        var y: CGFloat = 0
+        var y: Double = 0
         var next: Scanbeam?
     }
 
     class Maxima {
-        var x: CGFloat = 0
+        var x: Double = 0
         var next: Maxima?
         var prev: Maxima?
     }
@@ -432,7 +432,7 @@ public class ClipperBase {
         }
     }
     
-    func popLocalMinima(_ y: CGFloat, _ current:inout LocalMinima?) -> Bool {
+    func popLocalMinima(_ y: Double, _ current:inout LocalMinima?) -> Bool {
         current = currentLM
         if currentLM != nil && currentLM!.y == y {
             currentLM = currentLM!.next
@@ -467,7 +467,7 @@ public class ClipperBase {
         activeEdges = nil
     }
     
-    func insertScanbeam(_ y: CGFloat) {
+    func insertScanbeam(_ y: Double) {
         //single-linked list: sorted descending, ignoring dups.
         if scanbeam == nil {
             scanbeam = Scanbeam()
@@ -493,7 +493,7 @@ public class ClipperBase {
         }
     }
     
-    func popScanbeam(_ y:inout CGFloat) -> Bool {
+    func popScanbeam(_ y:inout Double) -> Bool {
         if scanbeam == nil {
             y = 0
             return false

--- a/Sources/SwiftClipper/Defines.swift
+++ b/Sources/SwiftClipper/Defines.swift
@@ -44,6 +44,6 @@ enum PointSideType: Int {
     case onBoundary = -1
 }
 
-let Horizontal = -CGFloat.greatestFiniteMagnitude;
+let Horizontal = -Double.greatestFiniteMagnitude;
 let Unassigned = -1;  //edge not currently 'owning' a solution
 let Skip = -2;        //edge that would otherwise close a path

--- a/Sources/SwiftClipper/Offsetter.swift
+++ b/Sources/SwiftClipper/Offsetter.swift
@@ -13,23 +13,23 @@ public class Offsetter {
     private var srcPoly = Path()
     private var destPoly = Path()
     private var normals = Path()
-    private var delta = CGFloat.zero
-    private var sinA = CGFloat.zero
-    private var sin = CGFloat.zero
-    private var cos = CGFloat.zero
-    private var miterLim = CGFloat.zero
-    private var stepsPerRad = CGFloat.zero
+    private var delta = Double.zero
+    private var sinA = Double.zero
+    private var sin = Double.zero
+    private var cos = Double.zero
+    private var miterLim = Double.zero
+    private var stepsPerRad = Double.zero
     
     private var lowest = CGPoint.zero
     private var polyNodes = PolyNode()
     
-    public var arcTolerance = CGFloat.zero
-    public var miterLimit = CGFloat.zero
+    public var arcTolerance = Double.zero
+    public var miterLimit = Double.zero
     
-    private let TwoPi = CGFloat.pi * 2
-    private let ArcTolerance: CGFloat = 0.25
+    private let TwoPi = Double.pi * 2
+    private let ArcTolerance: Double = 0.25
     
-    public init(miterLimit: CGFloat = 2.0, arcTolerance: CGFloat = 0.25) {
+    public init(miterLimit: Double = 2.0, arcTolerance: Double = 0.25) {
         self.miterLimit = miterLimit
         self.arcTolerance = arcTolerance
         lowest.x = -1
@@ -138,7 +138,7 @@ public class Offsetter {
     }
     
     
-    private func doOffset(_ delta: CGFloat) {
+    private func doOffset(_ delta: Double) {
         destPolys = Paths()
         self.delta = delta
         
@@ -159,7 +159,7 @@ public class Offsetter {
             miterLim = 0.5
         }
         
-        var y = CGFloat.zero
+        var y = Double.zero
         if arcTolerance <= 0.0 {
             y = ArcTolerance
         }
@@ -169,7 +169,7 @@ public class Offsetter {
             y = arcTolerance
         }
         //see offset_triginometry2.svg in the documentation folder ...
-        let steps = CGFloat.pi / acos(1 - y / abs(delta))
+        let steps = Double.pi / acos(1 - y / abs(delta))
         
         sin = CoreGraphics.sin(TwoPi / steps)
         cos = CoreGraphics.cos(TwoPi / steps)
@@ -192,17 +192,17 @@ public class Offsetter {
             
             if len == 1 {
                 if node.joinType == .round {
-                    var x: CGFloat = 1.0
-                    var y: CGFloat = 0.0
-                    for _ in 1...steps.int {
+                    var x: Double = 1.0
+                    var y: Double = 0.0
+                    for _ in 1...Int(steps) {
                         destPoly.append([round(srcPoly[0].x + x * delta), round(srcPoly[0].y + y * delta)])
                         let x2 = x
                         x = x * cos - sin * y
                         y = x2 * sin + y * cos
                     }
                 } else {
-                    var x: CGFloat = -1.0
-                    var y: CGFloat = -1.0
+                    var x: Double = -1.0
+                    var y: Double = -1.0
                     for _ in 0...3 {
                         destPoly.append([round(srcPoly[0].x + x * delta), round(srcPoly[0].y + y * delta)])
                         if x < 0 {
@@ -320,7 +320,7 @@ public class Offsetter {
     }
     
     
-    public func execute(_ solution: inout Paths,  delta: CGFloat) throws {
+    public func execute(_ solution: inout Paths,  delta: Double) throws {
 
         fixOrientations ()
         doOffset(delta)
@@ -356,7 +356,7 @@ public class Offsetter {
     }
     
     
-    public func execute(_ solution: PolyTree,  delta: CGFloat) throws {
+    public func execute(_ solution: PolyTree,  delta: Double) throws {
         fixOrientations ()
         doOffset(delta)
         
@@ -448,7 +448,7 @@ public class Offsetter {
     }
 
 
-    private func doMiter (_ j: Int, _ k: Int, _ r: CGFloat) {
+    private func doMiter (_ j: Int, _ k: Int, _ r: Double) {
         let q = delta / r
         destPoly.append([round(srcPoly[j].x + (normals[k].x + normals[j].x) * q),round(srcPoly[j].y + (normals[k].y + normals[j].y) * q)])
     }
@@ -459,7 +459,7 @@ public class Offsetter {
         
         var x = normals[k].x
         var y = normals[k].y
-        var x2 = CGFloat.zero
+        var x2 = Double.zero
         for _ in 0..<steps {
             destPoly.append([round(srcPoly[j].x + x * delta),round(srcPoly[j].y + y * delta)])
             x2 = x

--- a/Sources/SwiftClipper/OutRec.swift
+++ b/Sources/SwiftClipper/OutRec.swift
@@ -35,7 +35,7 @@ extension OutRec: Equatable {
 }
 
 extension OutRec {
-    var area: CGFloat {
+    var area: Double {
         return self.pts?.area ?? 0.0
     }
 }
@@ -54,9 +54,9 @@ extension OutPt: Equatable {
 }
 
 extension OutPt {
-    var area: CGFloat {
+    var area: Double {
         var current = self
-        var a: CGFloat = 0.0
+        var a: Double = 0.0
         repeat {
             a += (prev.pt.y + current.pt.x) * (prev.pt.y - current.pt.y)
             current = current.next
@@ -92,8 +92,8 @@ extension OutPt {
                     if op.next.pt.x > pt.x {
                         result = 1 - result
                     } else {
-                        let d = CGFloat((op.pt.x - pt.x) * (op.next.pt.y - pt.y)) -
-                            CGFloat((op.next.pt.x - pt.x) * (op.pt.y - pt.y))
+                        let d = Double((op.pt.x - pt.x) * (op.next.pt.y - pt.y)) -
+                            Double((op.next.pt.x - pt.x) * (op.pt.y - pt.y))
                         if d == 0 {
                             return -1
                         }
@@ -103,8 +103,8 @@ extension OutPt {
                     }
                 } else {
                     if op.next.pt.x > pt.x {
-                        let d = CGFloat((op.pt.x - pt.x) * (op.next.pt.y - pt.y)) -
-                            CGFloat((op.next.pt.x - pt.x) * (op.pt.y - pt.y))
+                        let d = Double((op.pt.x - pt.x) * (op.next.pt.y - pt.y)) -
+                            Double((op.next.pt.x - pt.x) * (op.pt.y - pt.y))
                         if d == 0 {
                             return -1
                         }

--- a/Sources/SwiftClipper/Path+Clipper.swift
+++ b/Sources/SwiftClipper/Path+Clipper.swift
@@ -63,7 +63,7 @@ extension Path {
         return result!
     }
     
-    public func cleanPolygon(distance: CGFloat = 1.415) -> Path {
+    public func cleanPolygon(distance: Double = 1.415) -> Path {
         //distance = proximity in units/pixels below which vertices will be stripped.
         //Default ~= sqrt(2) so when adjacent vertices or semi-adjacent vertices have
         //both x & y coords within 1 unit, then the second vertex will be stripped.
@@ -225,7 +225,7 @@ extension Paths {
         return result
     }
     
-    public func cleanPolygons(distance: CGFloat) -> Paths {
+    public func cleanPolygons(distance: Double) -> Paths {
         var result = Paths()
         for i in self.indices {
             result.append(self[i].cleanPolygon(distance: distance))

--- a/Sources/SwiftClipper/Path+Geometry.swift
+++ b/Sources/SwiftClipper/Path+Geometry.swift
@@ -10,13 +10,13 @@ import CoreGraphics
 
 extension Path {
     
-    public var area: CGFloat {
+    public var signedArea: Double {
         let size = self.count
         if size < 3 {
             return 0
         }
         
-        var a:CGFloat = 0.0
+        var a:Double = 0.0
         var i = 0
         while i < self.count - 1 {
             a += self[i].x * self[i+1].y
@@ -25,11 +25,11 @@ extension Path {
         }
         a += self[count-1].x * self[0].y
         a -= self[0].x * self[count-1].y
-        return abs(a * 0.5)
+        return a * 0.5
     }
     
-    public var circumference: CGFloat {
-        var distance:CGFloat = 0
+    public var circumference: Double {
+        var distance:Double = 0
         if self.count < 2 {
             return distance
         }
@@ -43,7 +43,7 @@ extension Path {
     
     public var centroid:CGPoint {
         var center = CGPoint.zero
-        let polygonArea = area
+        let polygonArea = abs(self.signedArea)
         for index in 0...self.count-1 {
             let vertice = self[index]
             let verticeNext = self[(index+1) % self.count]
@@ -58,7 +58,7 @@ extension Path {
     }
     
     public var orientation: Bool {
-        return self.area >= 0
+        return self.signedArea >= 0
     }
     
     //See "The Point in Polygon Problem for Arbitrary Polygons" by Hormann & Agathos
@@ -85,8 +85,8 @@ extension Path {
                     if ipNext.x > pt.x {
                         result = 1 - result
                     }else {
-                        let d = CGFloat((ip.x - pt.x) * (ipNext.y - pt.y)) -
-                            CGFloat((ipNext.x - pt.x) * (ip.y - pt.y))
+                        let d = Double((ip.x - pt.x) * (ipNext.y - pt.y)) -
+                            Double((ipNext.x - pt.x) * (ip.y - pt.y))
                         if d == 0 {
                             return -1
                         }
@@ -96,8 +96,8 @@ extension Path {
                     }
                 } else {
                     if ipNext.x > pt.x {
-                        let d = CGFloat((ip.x - pt.x) * (ipNext.y - pt.y)) -
-                            CGFloat((ipNext.x - pt.x) * (ip.y - pt.y))
+                        let d = Double((ip.x - pt.x) * (ipNext.y - pt.y)) -
+                            Double((ipNext.x - pt.x) * (ip.y - pt.y))
                         if d == 0 {
                             return -1
                         }
@@ -114,10 +114,10 @@ extension Path {
     
     /// Simplify the polygon with Ramer–Douglas–Peucker algorithm.
     /// - Parameter epsilon: Threshold value.
-     func simplify(_ epsilon:CGFloat) -> Path {
+     func simplify(_ epsilon:Double) -> Path {
          var simplePolygon = Path()
          var maxIndex = 0
-         var maxDistance = CGFloat.leastNormalMagnitude
+         var maxDistance = Double.leastNormalMagnitude
          if self.count-2 > 1 {
              
              for index in 1...self.count-2 {

--- a/Sources/SwiftClipper/Path+Offsetter.swift
+++ b/Sources/SwiftClipper/Path+Offsetter.swift
@@ -10,7 +10,7 @@ import CoreGraphics
 
 extension Path {
     
-    public func offset(_ delta: CGFloat) -> Paths {
+    public func offset(_ delta: Double) -> Paths {
         let o = Offsetter()
         var solution = Paths()
         o.addPath(self, joinType: .miter, endType: .closedLine)

--- a/Sources/SwiftClipper/Point.swift
+++ b/Sources/SwiftClipper/Point.swift
@@ -7,9 +7,9 @@
 
 import CoreGraphics
 
-extension CGPoint: ExpressibleByArrayLiteral {
+extension CGPoint: @retroactive ExpressibleByArrayLiteral {
     
-    public init(arrayLiteral elements: CGFloat...) {
+  public init(arrayLiteral elements: Double...) {
         self.init()
         if elements.count > 1 {
             self.x = elements[0]
@@ -41,13 +41,13 @@ extension CGPoint {
         return (self.y > pt1.y) == (self.y < pt2.y)
     }
     
-    public func distance(to point: CGPoint) -> CGFloat {
+    public func distance(to point: CGPoint) -> Double {
         let dx = self.x-point.x
         let dy = self.y-point.y
         return sqrt(dx*dx+dy*dy)
     }
     
-    public func distanceFromLineSqrd(_ ln1: CGPoint, _ ln2: CGPoint) -> CGFloat {
+    public func distanceFromLineSqrd(_ ln1: CGPoint, _ ln2: CGPoint) -> Double {
         //The equation of a line in general form (Ax + By + C = 0)
         //given 2 points (x¹,y¹) & (x²,y²) is ...
         //(y¹ - y²)x + (x² - x¹)y + (y² - y¹)x¹ - (x² - x¹)y¹ = 0
@@ -61,7 +61,7 @@ extension CGPoint {
         return (C * C) / (A * A + B * B)
     }
     
-    public func slopesNearCollinear(pt2: CGPoint, pt3: CGPoint, distSqrd: CGFloat) -> Bool {
+    public func slopesNearCollinear(pt2: CGPoint, pt3: CGPoint, distSqrd: Double) -> Bool {
         //this function is more accurate when the point that's GEOMETRICALLY
         //between the other 2 points is the one that's tested for distance.
         //nb: with 'spikes', either pt1(self) or pt3 is geometrically between the other pts
@@ -86,7 +86,7 @@ extension CGPoint {
         }
     }
     
-    public func areClose(pt pt2: CGPoint, distSqrd: CGFloat) -> Bool {
+    public func areClose(pt pt2: CGPoint, distSqrd: Double) -> Bool {
         let dx = self.x - pt2.x
         let dy = self.y - pt2.y
         return ((dx * dx) + (dy * dy) <= distSqrd)
@@ -108,11 +108,11 @@ extension CGPoint {
         left = CGPoint(x: left.x+right.x,y: left.y+right.y)
     }
 
-    static func * (left:CGPoint,right:CGFloat) -> CGPoint {
+    static func * (left:CGPoint,right:Double) -> CGPoint {
         return CGPoint(x: left.x*right,y: left.y*right)
     }
 
-    static func / (left:CGPoint,right:CGFloat) -> CGPoint {
+    static func / (left:CGPoint,right:Double) -> CGPoint {
         return CGPoint(x: left.x/right,y: left.y/right)
     }
 

--- a/Sources/SwiftClipper/Rect.swift
+++ b/Sources/SwiftClipper/Rect.swift
@@ -9,10 +9,10 @@ import Foundation
 import CoreGraphics
 
 public struct Rect: Equatable {
-    var left: CGFloat
-    var top: CGFloat
-    var right: CGFloat
-    var bottom: CGFloat
+    var left: Double
+    var top: Double
+    var right: Double
+    var bottom: Double
     
     static var zero:Rect {
         return Rect(left: 0, top: 0, right: 0, bottom: 0)
@@ -25,7 +25,7 @@ public struct Rect: Equatable {
 }
 
 extension CGRect {
-    var left: CGFloat {
+    var left: Double {
         set {
             origin.x = newValue
         }
@@ -34,7 +34,7 @@ extension CGRect {
         }
     }
     
-    var right: CGFloat {
+    var right: Double {
         set {
             size.width = newValue - left
         }
@@ -43,7 +43,7 @@ extension CGRect {
         }
     }
     
-    var top: CGFloat {
+    var top: Double {
         set {
             origin.y = newValue
         }
@@ -52,7 +52,7 @@ extension CGRect {
         }
     }
     
-    var bottom: CGFloat {
+    var bottom: Double {
         set {
             size.height = newValue - top
         }

--- a/Sources/SwiftClipper/TEdge.swift
+++ b/Sources/SwiftClipper/TEdge.swift
@@ -13,7 +13,7 @@ public class TEdge {
     var bot: CGPoint = .zero
     var curr: CGPoint = .zero  //current (updated for every new scanbeam)
     var top: CGPoint = .zero
-    var dx: CGFloat = 0.0
+    var dx: Double = 0.0
     var polyType: PolyType = .clip
     var side: EdgeSide = .left //side only refers to current side of solution poly
     var windDelta: Int = 0 //1 or -1 depending on winding direction
@@ -133,11 +133,11 @@ extension TEdge {
     }
 
     @inline(__always)
-    func topX(of currenty: CGFloat) -> CGFloat {
+    func topX(of currenty: Double) -> Double {
         if currenty == self.top.y {
             return self.top.x
         }
-        return self.bot.x + round(self.dx * (currenty - self.bot.y))
+        return self.bot.x + self.dx * (currenty - self.bot.y)
     }
     
     @inline(__always)
@@ -150,8 +150,8 @@ extension TEdge {
     
     func intersect(with edge: TEdge) -> CGPoint {
     
-        var b1:CGFloat = 0.0
-        var b2:CGFloat = 0.0
+        var b1:Double = 0.0
+        var b2:Double = 0.0
         var ip = CGPoint.zero
         if self.dx == edge.dx {
             ip.y = self.curr.y
@@ -165,7 +165,7 @@ extension TEdge {
                 ip.y = edge.bot.y
             } else {
                 b2 = edge.bot.y - (edge.bot.x / edge.dx)
-                ip.y = round(ip.x / edge.dx + b2)
+                ip.y = ip.x / edge.dx + b2
             }
         } else if edge.dx == 0 {
             ip.x = edge.bot.x
@@ -173,17 +173,17 @@ extension TEdge {
                 ip.y = self.bot.y
             } else {
                 b1 = self.bot.y - (self.bot.x / self.dx)
-                ip.y = round(ip.x / self.dx + b1)
+                ip.y = ip.x / self.dx + b1
             }
         } else {
             b1 = self.bot.x - self.bot.y * self.dx
             b2 = edge.bot.x - edge.bot.y * edge.dx
             let q = (b2-b1) / (self.dx - edge.dx)
-            ip.y = round(q)
+            ip.y = q
             if abs(self.dx) < abs(edge.dx) {
-                ip.x = round(self.dx * q + b1)
+                ip.x = self.dx * q + b1
             } else {
-                ip.x = round(edge.dx * q + b2)
+                ip.x = edge.dx * q + b2
             }
         }
         

--- a/Tests/SwiftClipperTests/DifferenceTests.swift
+++ b/Tests/SwiftClipperTests/DifferenceTests.swift
@@ -29,8 +29,8 @@ final class DifferenceTests: XCTestCase {
             [
                 CGPoint(x: 30, y: 0),
                 CGPoint(x: 25, y: 0),
-                CGPoint(x: 22, y: -10),
-                CGPoint(x: 25, y: -10), 
+                CGPoint(x: 23, y: -10),
+                CGPoint(x: 25, y: -10),
                 CGPoint(x: 25, y: -12),
                 CGPoint(x: 22, y: -12),
                 CGPoint(x: 20, y: -20),
@@ -39,9 +39,10 @@ final class DifferenceTests: XCTestCase {
                 CGPoint(x: 20, y: -30),
             ],
         ]
-        let differences = letterAPath.difference(letterAPath2)
+        let differences = roundPaths(letterAPath.difference(letterAPath2))
 
         XCTAssertEqual(differences.count, 2)
+
         XCTAssertEqual(differences[0], expectedDifferences[0])
         XCTAssertEqual(differences[1], expectedDifferences[1])
     }

--- a/Tests/SwiftClipperTests/IntersectionTests.swift
+++ b/Tests/SwiftClipperTests/IntersectionTests.swift
@@ -4,8 +4,8 @@ import XCTest
 final class IntersectionTests: XCTestCase {
 
     func testIntersection() {
-        let expectedIntersection = [CGPoint(x: 15, y: 5), CGPoint(x: 10, y: 0), CGPoint(x: 0, y: 5)]
-        let intersections = path.intersection(path2)
+        let expectedIntersection = [CGPoint(x: 200, y: -54), CGPoint(x: 200, y: -53), CGPoint(x: 100, y: 0), CGPoint(x: 150, y: 50), CGPoint(x: -3, y: 50)]
+        let intersections = roundPaths(path.intersection(path2))
         XCTAssertEqual(intersections.count, 1)
         XCTAssertEqual(intersections.first!, expectedIntersection)
     }
@@ -33,12 +33,12 @@ final class IntersectionTests: XCTestCase {
             ],
             [
                 CGPoint(x: 25, y: -10),
-                CGPoint(x: 22, y: -10),
+                CGPoint(x: 23, y: -10),
                 CGPoint(x: 22, y: -12),
                 CGPoint(x: 25, y: -12),
             ],
         ]
-        let intersections = letterAPath.intersection(letterAPath2)
+        let intersections = roundPaths(letterAPath.intersection(letterAPath2))
 
         XCTAssertEqual(intersections.count, 2)
         XCTAssertEqual(intersections[0], expectedIntersections[0])

--- a/Tests/SwiftClipperTests/UnionTests.swift
+++ b/Tests/SwiftClipperTests/UnionTests.swift
@@ -6,32 +6,35 @@ final class UnionTests: XCTestCase {
 
     func testUnion() {
         let expectedUnion: Path = [
-            CGPoint(x: 15, y: 5),
-            CGPoint(x: 20, y: 10),
-            CGPoint(x: -10, y: 10),
-            CGPoint(x: 0, y: 5),
-            CGPoint(x: -5, y: 5),
-            CGPoint(x: -5, y: -15),
-            CGPoint(x: 20, y: -15), 
-            CGPoint(x: 20, y: 5)
+            CGPoint(x: 200, y: -54),
+            CGPoint(x: 250, y: -80),
+            CGPoint(x: 200, y: -53),
+            CGPoint(x: 200, y: 50),
+            CGPoint(x: 150, y: 50),
+            CGPoint(x: 200, y: 100),
+            CGPoint(x: -100, y: 100),
+            CGPoint(x: -3, y: 50),
+            CGPoint(x: -50, y: 50),
+            CGPoint(x: -50.0, y: -150.0),
+            CGPoint(x: 200.0, y: -150.0),
         ]
-        let unions = path.union(path2)
+        let unions = roundPaths(path.union(path2))
         XCTAssertEqual(unions.count, 1)
         XCTAssertEqual(unions.first!, expectedUnion)
     }
 
     func testSimpleUnion() {
         let expectedUnion = [
-            CGPoint(x: 0, y: 0),
-            CGPoint(x: 0, y: 20),
-            CGPoint(x: 10, y: 20),
-            CGPoint(x: 10, y: 30),
-            CGPoint(x: 30, y: 30),
-            CGPoint(x: 30, y: 10),
-            CGPoint(x: 20, y: 10),
-            CGPoint(x: 20, y: 0),
+          CGPoint(x: 20, y: 0),
+          CGPoint(x: 20, y: 10),
+          CGPoint(x: 30, y: 10),
+          CGPoint(x: 30, y: 30),
+          CGPoint(x: 10, y: 30),
+          CGPoint(x: 10, y: 20),
+          CGPoint(x: 0, y: 20),
+          CGPoint(x: 0, y: 0),
         ]
-        let union = simplePath.union(simplePath2)
+        let union = roundPaths(simplePath.union(simplePath2))
         XCTAssertEqual(union.count, 1)
         XCTAssertEqual(union.first!, expectedUnion)
     }
@@ -41,7 +44,7 @@ final class UnionTests: XCTestCase {
             [
                 CGPoint(x: 30, y: 0),
                 CGPoint(x: 25, y: 0),
-                CGPoint(x: 22, y: -10),
+                CGPoint(x: 23, y: -10),
                 CGPoint(x: 13, y: -10),
                 CGPoint(x: 5, y: 0),
                 CGPoint(x: 0, y: 0),
@@ -57,7 +60,7 @@ final class UnionTests: XCTestCase {
                 CGPoint(x: 20, y: -20),
             ]
         ]
-        let unions = letterAPath.union(letterAPath2)
+        let unions = roundPaths(letterAPath.union(letterAPath2))
 
         XCTAssertEqual(unions.count, 2)
         XCTAssertEqual(unions[0], expectedUnions[0])

--- a/Tests/SwiftClipperTests/XorTests.swift
+++ b/Tests/SwiftClipperTests/XorTests.swift
@@ -23,7 +23,7 @@ final class XorTests: XCTestCase {
             ]
         ]
 
-        let xors = simplePath.xor(simplePath2)
+        let xors = roundPaths(simplePath.xor(simplePath2))
         XCTAssertEqual(xors.count, 2)
         XCTAssertEqual(xors[0], expectedXors[0])
         XCTAssertEqual(xors[1], expectedXors[1])
@@ -34,11 +34,11 @@ final class XorTests: XCTestCase {
             [
                 CGPoint(x: 30, y: 0), 
                 CGPoint(x: 25, y: 0), 
-                CGPoint(x: 22, y: -10),
+                CGPoint(x: 23, y: -10),
                 CGPoint(x: 25, y: -10),
                 CGPoint(x: 25, y: -12),
                 CGPoint(x: 22, y: -12),
-                CGPoint(x: 22, y: -10),
+                CGPoint(x: 23, y: -10),
                 CGPoint(x: 13, y: -10),
                 CGPoint(x: 5, y: 0),
                 CGPoint(x: 0, y: 0),
@@ -56,8 +56,8 @@ final class XorTests: XCTestCase {
                 CGPoint(x: 20, y: -30),
             ],
         ]
-        let xors = letterAPath.xor(letterAPath2)
-
+        let xors = roundPaths(letterAPath.xor(letterAPath2))
+      
         XCTAssertEqual(xors.count, 1)
         XCTAssertEqual(xors[0], expectedXors[0])
     }

--- a/Tests/SwiftClipperTests/data/testPaths.swift
+++ b/Tests/SwiftClipperTests/data/testPaths.swift
@@ -2,16 +2,16 @@ import CoreGraphics
 
 // A rectangle intersecting a triangle-like polygon that has an extra point which causes a very thin offshoot
 let path = [
-    CGPoint(x: -10, y: 10),
-    CGPoint(x: 20, y: 10),
-    CGPoint(x: 10, y: 0),
-    CGPoint(x: 25, y: -8)
+    CGPoint(x: -100, y: 100),
+    CGPoint(x: 200, y: 100),
+    CGPoint(x: 100, y: 0),
+    CGPoint(x: 250, y: -80)
 ]
 let path2 = [
-    CGPoint(x: -5, y: 5),
-    CGPoint(x: 20, y: 5),
-    CGPoint(x: 20, y: -15),
-    CGPoint(x: -5, y: -15)
+    CGPoint(x: -50, y: 50),
+    CGPoint(x: 200, y: 50),
+    CGPoint(x: 200, y: -150),
+    CGPoint(x: -50, y: -150)
 ]
 
 // Two intersecting squares
@@ -35,3 +35,12 @@ let letterAPath2 = [
     CGPoint(x: 25, y: -12),
     CGPoint(x: 0, y: -12),
 ]
+
+
+func roundPaths(_ paths: [[CGPoint]]) -> [[CGPoint]] {
+  return paths.map { path in
+    return path.map { point in
+      return CGPoint(x: round(point.x), y: round(point.y))
+    }
+  }
+}


### PR DESCRIPTION
This change updates SwiftClipper to use Double precision for all the calculations. This can break on 32-bit builds because CGPoint uses single-precision floats on 32-bit targets.

There also were several bugfixes:
1. Path orientation was always `positive` because the `area` method used `abs()`. I replaced it with a `signedArea` method.
2. `parseFirstLeft` method can return `nil`s, so I removed unwrapping from it.

I also fixed the tests to utilize the full un-rounded precision.